### PR TITLE
前後半年の日付のみ有効にした

### DIFF
--- a/src/pages/signed/MyCalendar.jsx
+++ b/src/pages/signed/MyCalendar.jsx
@@ -1,46 +1,71 @@
-import React from "react";
-import { View, Text} from "react-native";
+import React, {useState} from "react";
+import { View, Tex, StyleSheet } from "react-native";
 import { Calendar, CalendarList, Agenda } from "react-native-calendars";
-import {Box} from 'native-base';
+import { Box, NativeBaseProvider } from "native-base";
+import Icon from "react-native-vector-icons/Ionicons";
 
 const MyCalendar = () => {
+  const today = new Date();
+	const halfYearAgo = new Date(today.getFullYear(), today.getMonth() - 6, 2)
+	const halfYearAfter = new Date(today.getFullYear(), today.getMonth() + 6, 0)
 
-	const today = new Date()
+	// 日付を選択したら、選択した日付の色を変えたい
+	const [selectedDate, setSelectedDate] = useState();
+
+	// 選択している日付を更新する関数
+	const updateSelectedDate = (day) => {
+		setSelectedDate(day);
+	}
+
   return (
+    <NativeBaseProvider>
       <Calendar
-        current={today.toLocaleDateString()} 
-        minDate={today.setMonth(today.getMonth + 6).toLocaleDateString} 
-				maxDate={today.setMonth(today.getMonth - 6).toLocaleDateString} 
-				onDayPress={day => {
-					console.log('selected day', day);
-				}}
-				onDayLongPress={day => {
-					console.log('selected day', day);
-				}}
-				monthFormat={'yyyy MM'}
-				onMonthChange={month => {
-					console.log('month changed', month);
-				}}
-				hideArrows={true}
-				renderArrow={direction => <Arrow />}
+        current={today.dateString}
+				minDate={halfYearAgo.toISOString().toString()}
+        maxDate={halfYearAfter.toISOString().toString()}
+        onDayPress={(day) => {
+					updateSelectedDate(day)
+					// todo : CardAresに渡す引数を変える処理
+        }}
 
-				firstDay={0}
-				
-				enableSwipeMonths={true}
+        // onDayLongPress={(day) => {
+        //   console.log("selected day", day);
+        // }}
 
-				// Handler which gets executed when press arrow icon left. It receive a callback can go back month
-				onPressArrowLeft={subtractMonth => subtractMonth()}
-				// Handler which gets executed when press arrow icon right. It receive a callback can go next month
-				onPressArrowRight={addMonth => addMonth()}
-				// Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates
-				disableAllTouchEventsForDisabledDays={true}
-				// Replace default month and year title with custom one. the function receive a date as parameter
-				renderHeader={date => {
-					/*Return JSX*/
-				}}
-			
-				// markedDates={{{today.toLocaleDateString}:{selected:true}}}
-			/>
+        monthFormat={"yyyy MM"}
+        onMonthChange={(month) => {
+          console.log("month changed", month);
+        }}
+        renderArrow={(direction) =>
+          direction === "left" ? <Icon name="arrow-back-outline" size="40" color="#2296F3"/> : <Icon name="arrow-forward-outline" size="40" color="#2296F3" />
+        }
+        firstDay={7}
+        enableSwipeMonths={true}
+        onPressArrowLeft={(subtractMonth) => subtractMonth()}
+        onPressArrowRight={(addMonth) => addMonth()}
+        disableAllTouchEventsForDisabledDays={true}
+        markedDates={{
+          "2022-06-04": { selected: true },
+          "2022-06-30": { marked: true },
+          "2022-06-04": { textColor: "blue" },
+          "2022-06-05": { textColor: "red" },
+					// 今選択されている日付に色をつけたい
+					selectedDate : {selected: true, marked: true, selectedColor: 'blue'}
+        }}
+        theme={{
+          "stylesheet.calendar.header": {
+            dayTextAtIndex0: {
+              color: "red",
+            },
+            dayTextAtIndex6: {
+              color: "blue",
+            },
+          },
+        }}
+      />
+
+      {/* <CardsArea/ cards={cards}> */}
+    </NativeBaseProvider>
   );
 };
 


### PR DESCRIPTION
## issue番号
#34

## やったこと
前後半年のみを黒文字にする処理
月移動の矢印を追加

## その他
選択した日付に応じて、色などが変わる処理がしたかったけど、うまくできませんでした....